### PR TITLE
Ensure opts is not nil before indexing

### DIFF
--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -1,7 +1,7 @@
 local lspkind = {}
 
 function lspkind.init(opts)
-    with_text = opts['with_text']
+    local with_text = opts == nil and true or opts['with_text']
 
     -- deliberate code repeat to avoid if cond
     -- or string concat on each symbol

--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -1,7 +1,7 @@
 local lspkind = {}
 
 function lspkind.init(opts)
-    local with_text = opts == nil and true or opts['with_text']
+    local with_text = opts == nil or opts['with_text']
 
     -- deliberate code repeat to avoid if cond
     -- or string concat on each symbol


### PR DESCRIPTION
- Adds a test for non-nil `opts` table before getting the value of `with_text`; appropriately defaults value for `with_text`
- Makes `with_text` a local variable rather than an implicit global