### PR TITLE
Feat: Add ability to customize symbols

### DIFF
--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -1,68 +1,57 @@
 local lspkind = {}
+local fmt = string.format
+
+local kind_symbols = {
+  Text = '',
+  Method = 'ƒ',
+  Function = '',
+  Constructor = '',
+  Variable = '',
+  Class = '',
+  Interface = 'ﰮ',
+  Module = '',
+  Property = '',
+  Unit = '',
+  Value = '',
+  Enum = '了',
+  Keyword = '',
+  Snippet = '﬌',
+  Color = '',
+  File = '',
+  Folder = '',
+  EnumMember = '',
+  Constant = '',
+  Struct = ''
+}
+
+local kind_order = {
+  'Text', 'Method', 'Function', 'Constructor', 'Field', 'Variable', 'Class', 'Interface', 'Module',
+  'Property', 'Unit', 'Value', 'Enum', 'Keyword', 'Snippet', 'Color', 'File', 'Reference', 'Folder',
+  'EnumMember', 'Constant', 'Struct', 'Event', 'Operator', 'TypeParameter'
+}
 
 function lspkind.init(opts)
-    local with_text = opts == nil or opts['with_text']
+  local with_text = opts == nil or opts['with_text']
+  local symbol_map = (opts and opts['symbol_map'] and
+                       vim.tbl_extend('force', kind_symbols, opts['symbol_map'])) or kind_symbols
 
-    -- deliberate code repeat to avoid if cond
-    -- or string concat on each symbol
-
-    if with_text == true or with_text == nil then
-        require('vim.lsp.protocol').CompletionItemKind = {
-            ' Text';        -- = 1
-            'ƒ Method';      -- = 2;
-            ' Function';    -- = 3;
-            ' Constructor'; -- = 4;
-            'Field';         -- = 5;
-            ' Variable';    -- = 6;
-            ' Class';       -- = 7;
-            'ﰮ Interface';   -- = 8;
-            ' Module';      -- = 9;
-            ' Property';    -- = 10;
-            ' Unit';        -- = 11;
-            ' Value';       -- = 12;
-            '了Enum';        -- = 13;
-            ' Keyword';     -- = 14;
-            '﬌ Snippet';     -- = 15;
-            ' Color';       -- = 16;
-            ' File';        -- = 17;
-            'Reference';     -- = 18;
-            ' Folder';      -- = 19;
-            ' EnumMember';  -- = 20;
-            ' Constant';    -- = 21;
-            ' Struct';      -- = 22;
-            'Event';         -- = 23;
-            'Operator';      -- = 24;
-            'TypeParameter'; -- = 25;
-        }
-    else
-        require('vim.lsp.protocol').CompletionItemKind = {
-            '';             -- Text          = 1;
-            'ƒ';             -- Method        = 2;
-            '';             -- Function      = 3;
-            '';             -- Constructor   = 4;
-            'Field';         -- Field         = 5;
-            '';             -- Variable      = 6;
-            '';             -- Class         = 7;
-            'ﰮ';             -- Interface     = 8;
-            '';             -- Module        = 9;
-            '';             -- Property      = 10;
-            '';             -- Unit          = 11;
-            '';             -- Value         = 12;
-            '了';            -- Enum          = 13;
-            '';             -- Keyword       = 14;
-            '﬌';             -- Snippet       = 15;
-            '';             -- Color         = 16;
-            '';             -- File          = 17;
-            'Reference';     -- Reference     = 18;
-            '';             -- Folder        = 19;
-            '';             -- EnumMember    = 20;
-            '';             -- Constant      = 21;
-            '';             -- Struct        = 22;
-            'Event';         -- Event         = 23;
-            'Operator';      -- Operator      = 24;
-            'TypeParameter'; -- TypeParameter = 25;
-        }
+  local symbols = {}
+  local len = 25
+  if with_text == true or with_text == nil then
+    for i = 1, len do
+      local name = kind_order[i]
+      local symbol = symbol_map[name]
+      symbol = symbol and (symbol .. ' ') or ''
+      symbols[i] = fmt('%s%s', symbol, name)
     end
+  else
+    for i = 1, len do
+      local name = kind_order[i]
+      symbols[i] = symbol_map[name]
+    end
+  end
+
+  require('vim.lsp.protocol').CompletionItemKind = symbols
 end
 
 return lspkind


### PR DESCRIPTION
This PR adds the option to customize any subset of the kind symbols in a call to `init`. There are a few things to note:
- First, this PR necessarily removes the intentional code duplication, and does introduce a loop and (in the case of `with_text = true`) two concatenations. While this is less efficient than the original, this code should only run once (at LSP setup time) and is doing at most 50 concatenations, so the performance impact should be (imo) acceptable.
- Second, this PR **does** keep some intentional code duplication in having a separate loop for each of the `with_text` cases - this prevents the need to check the conditional on each iteration.