### PR TITLE
Expose kind_presets as public API

### DIFF
--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -99,4 +99,6 @@ function lspkind.init(opts)
   require('vim.lsp.protocol').CompletionItemKind = symbols
 end
 
+lspkind.presets = kind_presets
+
 return lspkind


### PR DESCRIPTION
This PR aims to improve usability of kind presets.

If this API is exposed, some plugins can be used `lspkind-nvim` more explicitly.