### PR TITLE
feat: Add `before` function callback for custom format

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,17 @@ require('lspkind').init({
 local lspkind = require('lspkind')
 cmp.setup {
   formatting = {
-    format = lspkind.cmp_format({with_text = false, maxwidth = 50})
+    format = lspkind.cmp_format({
+      with_text = false, -- do not show text alongside icons
+      maxwidth = 50, -- prevent the popup from showing more than provided characters (e.g 50 will not show more than 50 characters)
+      
+      -- The function below will be called before any actual modifications from lspkind
+      -- so that you can provide more controls on popup customization. (See [#30](https://github.com/onsails/lspkind-nvim/pull/30))
+      before = function (entry, vim_item)
+        ...
+        return vim_item
+      end
+    })
   }
 }
 ```

--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -126,6 +126,10 @@ function lspkind.cmp_format(opts)
   end
 
   return function(entry, vim_item)
+    if opts.before then
+          vim_item = opts.before(entry, vim_item)
+    end
+        
     vim_item.kind = lspkind.symbolic(vim_item.kind, opts)
 
     if opts.menu ~= nil then


### PR DESCRIPTION
Hello, this allows me to do something like this (just replaced `cb` with `before` though)

<img width="732" alt="Capture d’écran 2021-12-01 à 15 21 33" src="https://user-images.githubusercontent.com/5306901/144251095-e47a7c08-fc70-472b-a6ac-a794b88ef435.png">

In order to apply custom format:

<img width="435" alt="Capture d’écran 2021-12-01 à 15 23 27" src="https://user-images.githubusercontent.com/5306901/144251435-e32f7c7b-b7e1-4787-93bd-d703212d39eb.png">
