### PR TITLE
[lint] Line with spaces only

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cmp.setup {
     format = lspkind.cmp_format({
       with_text = false, -- do not show text alongside icons
       maxwidth = 50, -- prevent the popup from showing more than provided characters (e.g 50 will not show more than 50 characters)
-      
+
       -- The function below will be called before any actual modifications from lspkind
       -- so that you can provide more controls on popup customization. (See [#30](https://github.com/onsails/lspkind-nvim/pull/30))
       before = function (entry, vim_item)


### PR DESCRIPTION
My linter complain about this, so it must be something to avoid :-)

Thanx for the look and feel, it's a great UX :1st_place_medal: 