### PR TITLE
Add option to show only text (no symbols) #34 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Wherever you configure lsp put the following lua command:
 
 ```lua
 require('lspkind').init({
-    -- enables text annotations
+    -- DEPRECATED (use mode instead): enables text annotations
     --
     -- default: true
-    with_text = true,
+    -- with_text = true,
 
-    -- disables icons, overrides with_text to true
-    --
-    -- default: false
-    text_only = false,
+    -- defines how annotations are shown
+    -- default: symbol
+    -- options: 'text', 'text_symbol', 'symbol_text', 'symbol'
+    mode = 'symbol_text'
 
     -- default symbol map
     -- can be either 'default' (requires nerd-fonts font) or
@@ -70,7 +70,7 @@ local lspkind = require('lspkind')
 cmp.setup {
   formatting = {
     format = lspkind.cmp_format({
-      with_text = false, -- do not show text alongside icons
+      mode = 'symbol' -- show only symbol annotations
       maxwidth = 50, -- prevent the popup from showing more than provided characters (e.g 50 will not show more than 50 characters)
 
       -- The function below will be called before any actual modifications from lspkind

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ require('lspkind').init({
     -- default: true
     with_text = true,
 
+    -- disables icons, overrides with_text to true
+    --
+    -- default: false
+    text_only = false,
+
     -- default symbol map
     -- can be either 'default' (requires nerd-fonts font) or
     -- 'codicons' for codicon preset (requires vscode-codicons font)

--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -93,6 +93,7 @@ local modes = {
 -- default true
 -- deprecated
 local function opt_with_text(opts)
+  vim.api.nvim_command("echoerr 'DEPRECATED replaced by mode option.'")
   return opts == nil or opts['with_text'] == nil or opts['with_text']
 end
 

--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -72,6 +72,11 @@ local function opt_with_text(opts)
   return opts == nil or opts['with_text'] == nil or opts['with_text']
 end
 
+-- default false
+local function opt_text_only(opts)
+    return opts ~= nil and opts['text_only'] ~= nil and opts['text_only']
+end
+
 -- default 'default'
 local function opt_preset(opts)
   local preset
@@ -107,9 +112,12 @@ lspkind.symbol_map = kind_presets.default
 
 function lspkind.symbolic(kind, opts)
   local with_text = opt_with_text(opts)
+  local text_only = opt_text_only(opts)
 
   local symbol = lspkind.symbol_map[kind]
-  if with_text == true then
+  if text_only == true then
+      return kind
+  elseif with_text == true then
     symbol = symbol and (symbol .. ' ') or ''
     return fmt('%s%s', symbol, kind)
   else

--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -67,14 +67,44 @@ local kind_order = {
 }
 local kind_len = 25
 
+local function get_symbol(kind) 
+    local symbol = lspkind.symbol_map[kind]
+    return symbol or ''
+end
+
+local modes = { 
+    ['text'] = function(kind)
+        return kind
+    end, 
+    ['text_symbol'] = function(kind)
+        local symbol = get_symbol(kind)
+        return fmt("%s %s", kind, symbol)
+    end, 
+    ['symbol_text'] = function(kind)
+        local symbol = get_symbol(kind)
+        return fmt("%s %s", symbol, kind)
+    end, 
+    ['symbol']  = function(kind)
+        local symbol = get_symbol(kind)
+        return fmt("%s", symbol)
+    end 
+}
+
 -- default true
+-- deprecated
 local function opt_with_text(opts)
   return opts == nil or opts['with_text'] == nil or opts['with_text']
 end
 
--- default false
-local function opt_text_only(opts)
-    return opts ~= nil and opts['text_only'] ~= nil and opts['text_only']
+-- default 'symbol'
+local function opt_mode(opts) 
+    local mode = 'symbol'
+    if opt_with_text(opts) and opts ~= nil and opts['mode'] == nil then
+        mode = 'symbol_text'
+    elseif opts ~= nil and opts['mode'] ~= nil then
+        mode = opts['mode']
+    end
+    return mode
 end
 
 -- default 'default'
@@ -111,18 +141,15 @@ lspkind.presets = kind_presets
 lspkind.symbol_map = kind_presets.default
 
 function lspkind.symbolic(kind, opts)
-  local with_text = opt_with_text(opts)
-  local text_only = opt_text_only(opts)
+  local mode = opt_mode(opts)
+  local formatter = modes[mode]
 
-  local symbol = lspkind.symbol_map[kind]
-  if text_only == true then
-      return kind
-  elseif with_text == true then
-    symbol = symbol and (symbol .. ' ') or ''
-    return fmt('%s%s', symbol, kind)
-  else
-    return symbol
+  -- if someone enters an invalid mode, default to symbol
+  if formatter == nil then
+      formatter = modes['symbol']
   end
+
+  return formatter(kind)
 end
 
 function lspkind.cmp_format(opts)


### PR DESCRIPTION
Implements #34 

The PR will allow users to specify how the symbol and kind are displayed for annotations.

The added options are:

### 'text'
![text](https://user-images.githubusercontent.com/427379/152245913-a3f2a906-be13-493b-b40b-2f8fb45a725d.png)

### 'text_symbol' 
_I dont have a icon font installed, so they dont render in screenshot_
![text_symbol example](https://user-images.githubusercontent.com/427379/152246060-7b4e24d1-9c63-421d-8b80-9b4044f10457.png)

### 'symbol_text'
![symbol_text](https://user-images.githubusercontent.com/427379/152246280-40780d2c-0b6a-483d-bbce-6ee2d3f08874.png)

### 'symbol' (default)
![symbol](https://user-images.githubusercontent.com/427379/152246443-cc1f7939-4594-457b-bb10-ec8cc54641c3.png)

### Configuration changes

Adds `mode` option to configurations
```
       format = lspkind.cmp_format({
            mode = 'symbol',
            menu = ({
                buffer = "[buff]",
                nvim_lsp = "[lsp]",
                luasnip = "[snip]",
                path = "[path]"
            })
        })
```

- If `with_text` is set and `mode` is not set, the default behaviour of `with_text` applies.
- if `with_text` is set and `mode` is also set, use `mode`
- if both `with_text` and `mode` is not set, default to `symbol`
