### PR TITLE
Check if opts is nil before checking if 'with_text' option is present

### DIFF
--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -119,7 +119,7 @@ local function opt_preset(opts)
 end
 
 function lspkind.init(opts)
-  if opts['with_text'] ~= nil then
+  if opts~=nil and opts['with_text'] ~= nil then
     vim.api.nvim_command("echoerr 'DEPRECATED replaced by mode option.'")
   end
   local preset = opt_preset(opts)


### PR DESCRIPTION
Was raising an error on nvim startup if opts is nil (empty init function). This PR checks if opts is empty before hand.